### PR TITLE
fix: postcss conflict with px2rpx

### DIFF
--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -37,7 +37,7 @@ exports.cssLoaders = function (options) {
 
   // generate loader string to be used with extract text plugin
   function generateLoaders (loader, loaderOptions) {
-    var loaders = [cssLoader, postcssLoader, px2rpxLoader]
+    var loaders = [cssLoader, px2rpxLoader, postcssLoader]
     if (loader) {
       loaders.push({
         loader: loader + '-loader',


### PR DESCRIPTION
目前的 cssloader 的顺序会造成 postcss 中类似 precss 的插件无法使用
比如
`.class-a {
  .class-b {
 }
}`