### PR TITLE
fixed: 现在可以支持同时开启多个脚手架项目而不冲突了

### DIFF
--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -10,6 +10,7 @@ var path = require('path')
 var express = require('express')
 var webpack = require('webpack')
 var proxyMiddleware = require('http-proxy-middleware')
+var portfinder = require('portfinder')
 var webpackConfig = {{#if_or unit e2e}}(process.env.NODE_ENV === 'testing' || process.env.NODE_ENV === 'production')
   ? require('./webpack.prod.conf')
   : {{/if_or}}require('./webpack.dev.conf')
@@ -82,17 +83,26 @@ var readyPromise = new Promise(resolve => {
 //   _resolve()
 // })
 
-var server = app.listen(port, 'localhost')
-
-// for 小程序的文件保存机制
-require('webpack-dev-middleware-hard-disk')(compiler, {
-  publicPath: webpackConfig.output.publicPath,
-  quiet: true
+module.exports = new Promise((resolve, reject) => {
+  portfinder.basePort = port
+  portfinder.getPortPromise()
+  .then(newPort => {
+      if (port !== newPort) {
+        console.log(`${port}端口被占用，开启新端口${newPort}`)
+      }
+      var server = app.listen(newPort, 'localhost')
+      // for 小程序的文件保存机制
+      require('webpack-dev-middleware-hard-disk')(compiler, {
+        publicPath: webpackConfig.output.publicPath,
+        quiet: true
+      })
+      resolve({
+        ready: readyPromise,
+        close: () => {
+          server.close()
+        }
+      })
+  }).catch(error => {
+    console.log('没有找到空闲端口，请打开任务管理器杀死进程端口再试', error)
+  })
 })
-
-module.exports = {
-  ready: readyPromise,
-  close: () => {
-    server.close()
-  }
-}

--- a/template/build/dev-server.js
+++ b/template/build/dev-server.js
@@ -65,7 +65,7 @@ app.use(require('connect-history-api-fallback')())
 var staticPath = path.posix.join(config.dev.assetsPublicPath, config.dev.assetsSubDirectory)
 app.use(staticPath, express.static('./static'))
 
-var uri = 'http://localhost:' + port
+// var uri = 'http://localhost:' + port
 
 var _resolve
 var readyPromise = new Promise(resolve => {

--- a/template/package.json
+++ b/template/package.json
@@ -21,6 +21,7 @@
     "mpvue-loader": "^1.0.8",
     "mpvue-webpack-target": "^1.0.0",
     "mpvue-template-compiler": "^1.0.6",
+    "portfinder": "^1.0.13",
     "postcss-mpvue-wxss": "^1.0.0",
     "px2rpx-loader": "^0.1.8",
     "babel-core": "^6.22.1",


### PR DESCRIPTION
开发时，经常有打开多个项目的需求，然而现在的脚手架有端口冲突，故参照vue-cli的方式修复了这个问题，再开启服务器前先监测当前端口是否被占用，如果已经被占用则再分配一个空余端口