### PR TITLE
指定 webpack.base.conf 的 resolve.aliasFields 字段

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -47,6 +47,7 @@ module.exports = {
       '@': resolve('src')
     },
     symlinks: false,
+    aliasFields: ['mpvue', 'weapp', 'browser'],
     mainFields: ['browser', 'module', 'main']
   },
   module: {


### PR DESCRIPTION
以支持社区中利用 webpack aliasFields 特性为小程序或浏览器提供特定入口的 packages。

详细的背景介绍参见： https://github.com/Tencent/wepy/issues/566