### PR TITLE
fix: set miniprogramRoot to dist/wx

### DIFF
--- a/template/project.config.json
+++ b/template/project.config.json
@@ -7,7 +7,7 @@
 		"minified": true,
 		"newFeature": true
 	},
-	"miniprogramRoot": "./dist/",
+	"miniprogramRoot": "dist/wx/",
 	"compileType": "miniprogram",
 	"appid": "{{ appid }}",
 	"projectname": "{{ name }}",


### PR DESCRIPTION
现在 mpvue 构建出来的代码在 dist/wx 下面，所以 miniprogramRoot 也修改为 dist/wx/