### PR TITLE
fix: `miniprogramRoot` in built project.config.json

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -147,7 +147,14 @@ if (/^(swan)|(tt)$/.test(PLATFORM)) {
     plugins: [
       new CopyWebpackPlugin([{
         from: path.resolve(__dirname, projectConfigMap[PLATFORM]),
-        to: path.resolve(config.build.assetsRoot)
+        to: path.resolve(config.build.assetsRoot),
+        transform: (content) => {
+          const config = JSON.parse(content)
+          if (config.miniprogramRoot) {
+            config.miniprogramRoot = './'
+          }
+          return JSON.stringify(config, null, 2)
+        },
       }])
     ]
   })


### PR DESCRIPTION
修复 `miniprogramRoot` 在编译产物中出错的问题

原本 project.config.json 中为 `"miniprogramRoot": "dist/wx/"`，会出现以下问题

![image](https://user-images.githubusercontent.com/5810331/52988573-cc30ab80-343a-11e9-84e8-fe97bf2596e8.png)

修改为 `"miniprogramRoot": "./"`